### PR TITLE
Use a thunk instead of a direct reference to the canonical module

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -90,15 +90,15 @@ All methods' implementations should only use type information about arguments th
 
 ## Canonical Module
 
-A value may have a reference to a canonical module that works with values of that value's type. The reference should be in the `fantasy-land/canonical` property. For example:
+A value may have a reference to a canonical module that works with values of that value's type. Such a value should have a method named `fantasy-land/canonical` that returns the module. For example:
 
 ```js
 const ListModule = {
   of(x) {
-    return {'fantasy-land/canonical': ListModule, data: [x]}
+    return {'fantasy-land/canonical': () => ListModule, data: [x]}
   },
   map(f, v) {
-    return {'fantasy-land/canonical': ListModule, data: v.data.map(f)}
+    return {'fantasy-land/canonical': () => ListModule, data: v.data.map(f)}
   }
 }
 ```
@@ -115,10 +115,12 @@ const ListModule2 = {
   }
 }
 
-const list = {'fantasy-land/canonical': ListModule2, data: [1]}
+const list = {'fantasy-land/canonical': () => ListModule2, data: [1]}
 ```
 
 Note that the `ListModule2` here is correct. Only the `list` value doesn't follow the specification.
+
+The `fantasy-land/canonical` method must always return equivalent modules when called multiple times.
 
 
 ## Algebra


### PR DESCRIPTION
This was proposed by @alexandru in https://github.com/rpominov/static-land/issues/45#issuecomment-362885828 . It should make specification more flexible.

I don't have a strong opinion on this, and if there are no objections this seems like a good idea.