### PR TITLE
Drop prefix from canonical property

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project specifies interoperability of common algebraic structures. The main
 
 ### How to add compatibility with Fantasy Land to your library
 
-If your library defines a new type make sure that the values of that type have a reference to the canonical [module](specification.md#module) in the `fantasy-land/canonical` property [as described in the specification](specification.md#canonical-module).
+If your library defines a new type make sure that the values of that type have a reference to the canonical [module](specification.md#module) in the `canonical` property [as described in the specification](specification.md#canonical-module).
 
 In rare cases when it's impossible to add the property to values, for example when you define a module for a type that you cannot control, it's still useful to expose compatible [module objects](specification.md#module). Simply say in your documentation where the modules are located.
 

--- a/specification.md
+++ b/specification.md
@@ -92,15 +92,15 @@ All methods' implementations should only use type information about arguments th
 
 ## Canonical Module
 
-A value may have a reference to a canonical module that works with values of that value's type. The reference should be in the `fantasy-land/canonical` property. For example:
+A value may have a reference to a canonical module that works with values of that value's type. The reference should be in the `canonical` property. For example:
 
 ```js
 const ListModule = {
   of(x) {
-    return {'fantasy-land/canonical': ListModule, data: [x]}
+    return {'canonical': ListModule, data: [x]}
   },
   map(f, v) {
-    return {'fantasy-land/canonical': ListModule, data: v.data.map(f)}
+    return {'canonical': ListModule, data: v.data.map(f)}
   }
 }
 ```
@@ -117,7 +117,7 @@ const ListModule2 = {
   }
 }
 
-const list = {'fantasy-land/canonical': ListModule2, data: [1]}
+const list = {'canonical': ListModule2, data: [1]}
 ```
 
 Note that the `ListModule2` here is correct. Only the `list` value doesn't follow the specification.


### PR DESCRIPTION
This PR renames the canonical property from `fantasy-land/canonical` to just `canonical`.

As I mentioned in https://github.com/fantasyland/fantasy-land/pull/286 I think the prefix with a slash made more sense when there were many prefixed methods. By design, there is only a single canonical method. Having a "directory"-like prefix that is only ever going to have a single child seems a bit odd to me. It seems sufficient to just pick a name that is uncommon enough to no cause collisions. As far as I can tell `canonical` in itself does that job just fine.

Benefits:

* Shorter name is nice.
* The name doesn't contain special characters so the property can be accessed without brackets and quotes.  I.e. `thing.canonical` instead of `thing["fantasy-land/canonical"]`.
* IMO `fantasy-land/canonical` gives the misleading impression that there are several functions behind the prefix (like there was previously).